### PR TITLE
Rename IMS::LTI to IMS::LTI1_1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# IMS LTI
+# IMS LTI1_1
 
 This ruby library is to help create Tool Providers and Tool Consumers for the
 [IMS LTI standard](http://www.imsglobal.org/lti/index.html).
@@ -59,7 +59,7 @@ the request, you can initialize a `ToolProvider` object with them and the post p
 
 ```ruby
 # Initialize TP object with OAuth creds and post parameters
-provider = IMS::LTI::ToolProvider.new(consumer_key, consumer_secret, params)
+provider = IMS::LTI1_1::ToolProvider.new(consumer_key, consumer_secret, params)
 
 # Verify OAuth signature by passing the request object
 if provider.valid_request?(request)
@@ -114,13 +114,13 @@ This is covered in the [LTI security model](http://www.imsglobal.org/LTI/v1p1/lt
 
 ```ruby
 
-params = { user_id: '123', lti_message_type: IMS::LTI::Models::Messages::BasicLTILaunchRequest::MESSAGE_TYPE }
+params = { user_id: '123', lti_message_type: IMS::LTI1_1::Models::Messages::BasicLTI1_1LaunchRequest::MESSAGE_TYPE }
 
 header = SimpleOAuth::Header.new(:post, 'https://yoursite.com', params, consumer_key: oauth_consumer_key, consumer_secret: secret)
 
 signed_params = header.signed_attributes.merge(params)
 
-IMS::LTI::Services::MessageAuthenticator.new(launch_url, signed_params, secret)
+IMS::LTI1_1::Services::MessageAuthenticator.new(launch_url, signed_params, secret)
 
 ```
 

--- a/bin/publish.sh
+++ b/bin/publish.sh
@@ -3,7 +3,7 @@
 
 set -e
 
-current_version=$(ruby -e "require '$(pwd)/lib/ims/lti/version.rb'; puts IMS::LTI::VERSION;")
+current_version=$(ruby -e "require '$(pwd)/lib/ims/lti/version.rb'; puts IMS::LTI1_1::VERSION;")
 existing_versions=$(gem list --exact ims-lti --remote --all | grep -o '\((.*)\)$' | tr -d '() ')
 
 if [[ $existing_versions == *$current_version* ]]; then

--- a/ims-lti.gemspec
+++ b/ims-lti.gemspec
@@ -4,7 +4,7 @@ require 'ims/lti/version'
 
 Gem::Specification.new do |s|
   s.name = %q{ims-lti}
-  s.version = IMS::LTI::VERSION
+  s.version = IMS::LTI1_1::VERSION
 
   s.add_dependency 'builder', '>= 1.0', '< 4.0'
   s.add_dependency 'oauth', '>= 0.4.5'

--- a/lib/ims/lti.rb
+++ b/lib/ims/lti.rb
@@ -6,7 +6,7 @@ require 'securerandom'
 
 module IMS # :nodoc:
 
-  # :main:IMS::LTI
+  # :main:IMS::LTI1_1
   # LTI is a standard defined by IMS for creating eduction Tool Consumers/Providers.
   # LTI documentation: http://www.imsglobal.org/lti/index.html
   #
@@ -14,7 +14,7 @@ module IMS # :nodoc:
   # ToolConsumer classes.
   #
   # For validating OAuth request be sure to require the necessary proxy request
-  # object. See IMS::LTI::RequestValidator#valid_request? for more documentation.
+  # object. See IMS::LTI1_1::RequestValidator#valid_request? for more documentation.
   #
   # == Installation
   # This is packaged as the `ims-lti` rubygem, so you can just add the dependency to
@@ -25,7 +25,7 @@ module IMS # :nodoc:
   # To require the library in your project:
   #
   #    require 'ims/lti'
-  module LTI
+  module LTI1_1
 
     # The versions of LTI this library supports
     VERSIONS = %w{1.0 1.1}
@@ -38,7 +38,7 @@ module IMS # :nodoc:
 
     # POST a signed oauth request with the given key/secret/data
     def self.post_service_request(key, secret, url, content_type, body)
-      raise IMS::LTI::InvalidLTIConfigError, "" unless key && secret
+      raise IMS::LTI1_1::InvalidLTIConfigError, "" unless key && secret
 
       consumer = OAuth::Consumer.new(key, secret)
       token = OAuth::AccessToken.new(consumer)

--- a/lib/ims/lti/deprecated_role_checks.rb
+++ b/lib/ims/lti/deprecated_role_checks.rb
@@ -1,7 +1,7 @@
 # These are here for backwards-compatibility
 # But they are deprecated and the new ones in
 # role_checks.rb should be used
-module IMS::LTI
+module IMS::LTI1_1
 module DeprecatedRoleChecks
   # Check whether the Launch Parameters have a role
     def has_role?(role)

--- a/lib/ims/lti/extensions.rb
+++ b/lib/ims/lti/extensions.rb
@@ -1,5 +1,5 @@
 
-module IMS::LTI
+module IMS::LTI1_1
   module Extensions
     
     # Base functionality for creating LTI extension modules

--- a/lib/ims/lti/extensions/canvas.rb
+++ b/lib/ims/lti/extensions/canvas.rb
@@ -1,4 +1,4 @@
-module IMS::LTI
+module IMS::LTI1_1
   module Extensions
     # Module that adds Canvas specific LTI extensions
     #
@@ -8,11 +8,11 @@ module IMS::LTI
     # To generate an XML configuration:
     #
     #    # Create a config object and set some options
-    #    tc = IMS::LTI::ToolConfig.new(:title => "Example Sinatra Tool Provider", :launch_url => url)
+    #    tc = IMS::LTI1_1::ToolConfig.new(:title => "Example Sinatra Tool Provider", :launch_url => url)
     #    tc.description = "This example LTI Tool Provider supports LIS Outcome pass-back."
     #
     #    # Extend the Canvas Tool config and add canvas related extensions
-    #    tc.extend IMS::LTI::Extensions::Canvas::ToolConfig
+    #    tc.extend IMS::LTI1_1::Extensions::Canvas::ToolConfig
     #    tc.homework_submission! 'http://someplace.com/homework', 'Find Homework'
     #
     #    # generate the XML
@@ -20,7 +20,7 @@ module IMS::LTI
     #
     # Or to create a config object from an XML String:
     #
-    #    tc = IMS::LTI::ToolConfig.create_from_xml(xml)
+    #    tc = IMS::LTI1_1::ToolConfig.create_from_xml(xml)
 
     module Canvas
       module ToolConfig

--- a/lib/ims/lti/extensions/content.rb
+++ b/lib/ims/lti/extensions/content.rb
@@ -1,12 +1,12 @@
-module IMS::LTI
+module IMS::LTI1_1
   module Extensions
 
     # An LTI extension that adds support for content back to the consumer
     #
     #     # Initialize TP object with OAuth creds and post parameters
-    #     provider = IMS::LTI::ToolProvider.new(consumer_key, consumer_secret, params)
+    #     provider = IMS::LTI1_1::ToolProvider.new(consumer_key, consumer_secret, params)
     #     # add extension
-    #     provider.extend IMS::LTI::Extensions::Content::ToolProvider
+    #     provider.extend IMS::LTI1_1::Extensions::Content::ToolProvider
     #
     # If the tool was launched as an content request and it supports the content extension
     # you can redirect the user to the tool consumer using the return url helper methods.
@@ -20,7 +20,7 @@ module IMS::LTI
     #
     module Content
       module ToolProvider
-        include IMS::LTI::Extensions::ExtensionBase
+        include IMS::LTI1_1::Extensions::ExtensionBase
         include Base
 
         # a list of the supported outcome data types
@@ -210,7 +210,7 @@ module IMS::LTI
       end
 
       module ToolConsumer
-        include IMS::LTI::Extensions::ExtensionBase
+        include IMS::LTI1_1::Extensions::ExtensionBase
         include Base
         
         # a list of the content types accepted

--- a/lib/ims/lti/extensions/outcome_data.rb
+++ b/lib/ims/lti/extensions/outcome_data.rb
@@ -1,13 +1,13 @@
-module IMS::LTI
+module IMS::LTI1_1
   module Extensions
 
     # An LTI extension that adds support for sending data back to the consumer
     # in addition to the score.
     #
     #     # Initialize TP object with OAuth creds and post parameters
-    #     provider = IMS::LTI::ToolProvider.new(consumer_key, consumer_secret, params)
+    #     provider = IMS::LTI1_1::ToolProvider.new(consumer_key, consumer_secret, params)
     #     # add extension
-    #     provider.extend IMS::LTI::Extensions::OutcomeData::ToolProvider
+    #     provider.extend IMS::LTI1_1::Extensions::OutcomeData::ToolProvider
     #
     # If the tool was launch as an outcome service and it supports the data extension
     # you can POST a score to the TC.
@@ -30,15 +30,15 @@ module IMS::LTI
     #     end
     module OutcomeData
 
-      #IMS::LTI::Extensions::OutcomeData::ToolProvider
+      #IMS::LTI1_1::Extensions::OutcomeData::ToolProvider
       module Base
         def outcome_request_extensions
-          super + [IMS::LTI::Extensions::OutcomeData::OutcomeRequest]
+          super + [IMS::LTI1_1::Extensions::OutcomeData::OutcomeRequest]
         end
       end
 
       module ToolProvider
-        include IMS::LTI::Extensions::ExtensionBase
+        include IMS::LTI1_1::Extensions::ExtensionBase
         include Base
 
         # a list of the supported outcome data types
@@ -138,7 +138,7 @@ module IMS::LTI
       end
 
       module ToolConsumer
-        include IMS::LTI::Extensions::ExtensionBase
+        include IMS::LTI1_1::Extensions::ExtensionBase
         include Base
 
         OUTCOME_DATA_TYPES = %w{text url lti_launch_url submitted_at}
@@ -168,7 +168,7 @@ module IMS::LTI
       end
 
       module OutcomeRequest
-        include IMS::LTI::Extensions::ExtensionBase
+        include IMS::LTI1_1::Extensions::ExtensionBase
         include Base
 
         attr_accessor :outcome_text,

--- a/lib/ims/lti/launch_params.rb
+++ b/lib/ims/lti/launch_params.rb
@@ -1,4 +1,4 @@
-module IMS::LTI
+module IMS::LTI1_1
   # Mixin module for managing LTI Launch Data
   #
   # Launch data documentation:

--- a/lib/ims/lti/outcome_request.rb
+++ b/lib/ims/lti/outcome_request.rb
@@ -1,4 +1,4 @@
-module IMS::LTI
+module IMS::LTI1_1
   # Class for consuming/generating LTI Outcome Requests
   #
   # Outcome Request documentation: http://www.imsglobal.org/lti/v1p1pd/ltiIMGv1p1pd.html#_Toc309649691
@@ -17,7 +17,7 @@ module IMS::LTI
   # information in the request. Typical usage would be:
   #
   #    # create an OutcomeRequest from the request object
-  #    req = IMS::LTI::OutcomeRequest.from_post_request(request)
+  #    req = IMS::LTI1_1::OutcomeRequest.from_post_request(request)
   #
   #    # access the source id to identify the user who's grade you'd like to access
   #    req.lis_result_sourcedid
@@ -33,7 +33,7 @@ module IMS::LTI
   #      # return an unsupported OutcomeResponse
   #    end
   class OutcomeRequest < ToolBase
-    include IMS::LTI::Extensions::Base
+    include IMS::LTI1_1::Extensions::Base
 
     REPLACE_REQUEST = 'replaceResult'
     DELETE_REQUEST = 'deleteResult'
@@ -54,7 +54,7 @@ module IMS::LTI
 
     # Convenience method for creating a new OutcomeRequest from a request object
     #
-    #    req = IMS::LTI::OutcomeRequest.from_post_request(request)
+    #    req = IMS::LTI1_1::OutcomeRequest.from_post_request(request)
     def self.from_post_request(post_request)
       request = OutcomeRequest.new
       request.process_post_request(post_request)
@@ -121,7 +121,7 @@ module IMS::LTI
     #
     # @return [OutcomeResponse] The response from the Tool Consumer
     def post_outcome_request
-      raise IMS::LTI::InvalidLTIConfigError, "" unless has_required_attributes?
+      raise IMS::LTI1_1::InvalidLTIConfigError, "" unless has_required_attributes?
 
       res = post_service_request(@lis_outcome_service_url,
                                  'application/xml',
@@ -149,7 +149,7 @@ module IMS::LTI
     end
 
     def generate_request_xml
-      raise IMS::LTI::InvalidLTIConfigError, "`@operation` and `@lis_result_sourcedid` are required" unless has_request_xml_attributes?
+      raise IMS::LTI1_1::InvalidLTIConfigError, "`@operation` and `@lis_result_sourcedid` are required" unless has_request_xml_attributes?
       builder = Builder::XmlMarkup.new #(:indent=>2)
       builder.instruct!
 
@@ -157,7 +157,7 @@ module IMS::LTI
         env.imsx_POXHeader do |header|
           header.imsx_POXRequestHeaderInfo do |info|
             info.imsx_version "V1.0"
-            info.imsx_messageIdentifier @message_identifier || IMS::LTI::generate_identifier
+            info.imsx_messageIdentifier @message_identifier || IMS::LTI1_1::generate_identifier
           end
         end
         env.imsx_POXBody do |body|

--- a/lib/ims/lti/outcome_response.rb
+++ b/lib/ims/lti/outcome_response.rb
@@ -1,4 +1,4 @@
-module IMS::LTI
+module IMS::LTI1_1
   # Class for consuming/generating LTI Outcome Responses
   #
   # Response documentation: http://www.imsglobal.org/lti/v1p1pd/ltiIMGv1p1pd.html#_Toc309649691
@@ -21,7 +21,7 @@ module IMS::LTI
   # accessing the information in the request. Typical usage would be:
   #
   #    # create a new response and set the appropriate values
-  #    res = IMS::LTI::OutcomeResponse.new
+  #    res = IMS::LTI1_1::OutcomeResponse.new
   #    res.message_ref_identifier = outcome_request.message_identifier
   #    res.operation = outcome_request.operation
   #    res.code_major = 'success'
@@ -45,7 +45,7 @@ module IMS::LTI
   #    res.generate_response_xml
   #
   class OutcomeResponse
-    include IMS::LTI::Extensions::Base
+    include IMS::LTI1_1::Extensions::Base
 
     attr_accessor :request_type, :score, :message_identifier, :response_code,
             :post_response, :code_major, :severity, :description, :operation,
@@ -65,7 +65,7 @@ module IMS::LTI
 
     # Convenience method for creating a new OutcomeResponse from a response object
     #
-    #    req = IMS::LTI::OutcomeResponse.from_post_response(response)
+    #    req = IMS::LTI1_1::OutcomeResponse.from_post_response(response)
     def self.from_post_response(post_response)
       response = OutcomeResponse.new
       response.process_post_response(post_response)
@@ -108,7 +108,7 @@ module IMS::LTI
       begin
         doc = REXML::Document.new xml
       rescue => e
-        raise IMS::LTI::XMLParseError, "#{e}\nOriginal xml: '#{xml}'"
+        raise IMS::LTI1_1::XMLParseError, "#{e}\nOriginal xml: '#{xml}'"
       end
       @message_identifier = doc.text("//imsx_statusInfo/imsx_messageIdentifier").to_s
       @code_major = doc.text("//imsx_statusInfo/imsx_codeMajor")
@@ -133,7 +133,7 @@ module IMS::LTI
         env.imsx_POXHeader do |header|
           header.imsx_POXResponseHeaderInfo do |info|
             info.imsx_version "V1.0"
-            info.imsx_messageIdentifier @message_identifier || IMS::LTI::generate_identifier
+            info.imsx_messageIdentifier @message_identifier || IMS::LTI1_1::generate_identifier
             info.imsx_statusInfo do |status|
               status.imsx_codeMajor @code_major
               status.imsx_severity @severity

--- a/lib/ims/lti/request_validator.rb
+++ b/lib/ims/lti/request_validator.rb
@@ -1,4 +1,4 @@
-module IMS::LTI
+module IMS::LTI1_1
   # A mixin for OAuth request validation
   module RequestValidator
 

--- a/lib/ims/lti/role_checks.rb
+++ b/lib/ims/lti/role_checks.rb
@@ -1,4 +1,4 @@
-module IMS::LTI
+module IMS::LTI1_1
   # Some convenience methods for the most used roles
   # Take care when using context_ helpers, as the context of an LTI launch
   # determines the meaning of that role. For example, if the context is an

--- a/lib/ims/lti/tool_base.rb
+++ b/lib/ims/lti/tool_base.rb
@@ -1,8 +1,8 @@
-module IMS::LTI
+module IMS::LTI1_1
   class ToolBase
-    include IMS::LTI::Extensions::Base
-    include IMS::LTI::LaunchParams
-    include IMS::LTI::RequestValidator
+    include IMS::LTI1_1::Extensions::Base
+    include IMS::LTI1_1::LaunchParams
+    include IMS::LTI1_1::RequestValidator
 
     # OAuth credentials
     attr_accessor :consumer_key, :consumer_secret
@@ -19,7 +19,7 @@ module IMS::LTI
     # Convenience method for doing oauth signed requests to services that
     # aren't supported by this library
     def post_service_request(url, content_type, body)
-      IMS::LTI::post_service_request(@consumer_key,
+      IMS::LTI1_1::post_service_request(@consumer_key,
                                      @consumer_secret,
                                      url,
                                      content_type,

--- a/lib/ims/lti/tool_config.rb
+++ b/lib/ims/lti/tool_config.rb
@@ -1,4 +1,4 @@
-module IMS::LTI
+module IMS::LTI1_1
   # Class used to represent an LTI configuration
   #
   # It can create and read the Common Cartridge XML representation of LTI links
@@ -8,7 +8,7 @@ module IMS::LTI
   # To generate an XML configuration:
   #
   #    # Create a config object and set some options
-  #    tc = IMS::LTI::ToolConfig.new(:title => "Example Sinatra Tool Provider", :launch_url => url)
+  #    tc = IMS::LTI1_1::ToolConfig.new(:title => "Example Sinatra Tool Provider", :launch_url => url)
   #    tc.description = "This example LTI Tool Provider supports LIS Outcome pass-back."
   #
   #    # generate the XML
@@ -16,7 +16,7 @@ module IMS::LTI
   #
   # Or to create a config object from an XML String:
   #
-  #    tc = IMS::LTI::ToolConfig.create_from_xml(xml)
+  #    tc = IMS::LTI1_1::ToolConfig.create_from_xml(xml)
   class ToolConfig
     attr_reader :custom_params, :extensions
 
@@ -124,7 +124,7 @@ module IMS::LTI
 
     # Generate XML from the current settings
     def to_xml(opts = {})
-      raise IMS::LTI::InvalidLTIConfigError, "A launch url is required for an LTI configuration." unless self.launch_url || self.secure_launch_url
+      raise IMS::LTI1_1::InvalidLTIConfigError, "A launch url is required for an LTI1_1 configuration." unless self.launch_url || self.secure_launch_url
 
       builder = Builder::XmlMarkup.new(:indent => opts[:indent] || 0)
       builder.instruct!

--- a/lib/ims/lti/tool_consumer.rb
+++ b/lib/ims/lti/tool_consumer.rb
@@ -1,4 +1,4 @@
-module IMS::LTI
+module IMS::LTI1_1
   # Class for implementing an LTI Tool Consumer
   class ToolConsumer < ToolBase
     attr_accessor :launch_url, :timestamp, :nonce
@@ -37,7 +37,7 @@ module IMS::LTI
     #
     #
     def generate_launch_data
-      raise IMS::LTI::InvalidLTIConfigError, "Not all required params set for tool launch" unless has_required_params?
+      raise IMS::LTI1_1::InvalidLTIConfigError, "Not all required params set for tool launch" unless has_required_params?
 
       params = self.to_params
       params['lti_version'] ||= 'LTI-1p0'

--- a/lib/ims/lti/tool_provider.rb
+++ b/lib/ims/lti/tool_provider.rb
@@ -1,11 +1,11 @@
 require 'cgi'
 
-module IMS::LTI
+module IMS::LTI1_1
 
   # Class for implementing an LTI Tool Provider
   #
   #     # Initialize TP object with OAuth creds and post parameters
-  #     provider = IMS::LTI::ToolProvider.new(consumer_key, consumer_secret, params)
+  #     provider = IMS::LTI1_1::ToolProvider.new(consumer_key, consumer_secret, params)
   #
   #     # Verify OAuth signature by passing the request object
   #     if provider.valid_request?(request)
@@ -112,7 +112,7 @@ module IMS::LTI
     #
     # Example:
     #
-    #    tc = IMS::LTI::tc.new
+    #    tc = IMS::LTI1_1::tc.new
     #    tc.launch_presentation_return_url = "http://example.com/return"
     #    tc.lti_msg = "hi there"
     #    tc.lti_errorlog = "error happens"

--- a/lib/ims/lti/version.rb
+++ b/lib/ims/lti/version.rb
@@ -1,5 +1,5 @@
 module IMS
-  module LTI
+  module LTI1_1
     VERSION = '1.2.9'.freeze
   end
 end

--- a/spec/extensions/base_spec.rb
+++ b/spec/extensions/base_spec.rb
@@ -11,7 +11,7 @@ module TestLTIExtension
   end
 
   module ToolProvider
-    include IMS::LTI::Extensions::ExtensionBase
+    include IMS::LTI1_1::Extensions::ExtensionBase
     include Base
     
     def tp_test
@@ -20,7 +20,7 @@ module TestLTIExtension
   end
 
   module ToolConsumer
-    include IMS::LTI::Extensions::ExtensionBase
+    include IMS::LTI1_1::Extensions::ExtensionBase
     include Base
     
     def special_key=(val)
@@ -33,7 +33,7 @@ module TestLTIExtension
   end
 
   module OutcomeRequest
-    include IMS::LTI::Extensions::ExtensionBase
+    include IMS::LTI1_1::Extensions::ExtensionBase
     include Base
     
     attr_accessor :test_val
@@ -49,7 +49,7 @@ module TestLTIExtension
   end
 
   module OutcomeResponse
-    include IMS::LTI::Extensions::ExtensionBase
+    include IMS::LTI1_1::Extensions::ExtensionBase
     include Base
 
     def response_test
@@ -58,7 +58,7 @@ module TestLTIExtension
   end
 end
 
-describe IMS::LTI::Extensions do
+describe IMS::LTI1_1::Extensions do
   before do
     create_test_tp
     @tp.extend TestLTIExtension::ToolProvider
@@ -69,7 +69,7 @@ describe IMS::LTI::Extensions do
   end
   
   it "should add TC functionality" do
-    tc = IMS::LTI::ToolConsumer.new("hey", "ho")
+    tc = IMS::LTI1_1::ToolConsumer.new("hey", "ho")
     tc.extend TestLTIExtension::ToolConsumer
     tc.special_key = 'hey'
     tc.special_key.should == 'hey'
@@ -83,7 +83,7 @@ describe IMS::LTI::Extensions do
   end
   
   it "should parse replaceResult xml with extension val" do
-    req = IMS::LTI::OutcomeRequest.new
+    req = IMS::LTI1_1::OutcomeRequest.new
     req.extend TestLTIExtension::OutcomeRequest
     req.process_xml(result_xml % %{<testVal>hey there</testVal>})
     req.test_val.should == 'hey there'

--- a/spec/extensions/canvas_spec.rb
+++ b/spec/extensions/canvas_spec.rb
@@ -1,9 +1,9 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper.rb')
 
-describe IMS::LTI::Extensions do
+describe IMS::LTI1_1::Extensions do
   subject(:tc) do
-    tc = IMS::LTI::ToolConfig.new("title" => "Test Config", "secure_launch_url" => "https://www.example.com/lti", "custom_params" => {"custom1" => "customval1"})
-    tc.extend IMS::LTI::Extensions::Canvas::ToolConfig
+    tc = IMS::LTI1_1::ToolConfig.new("title" => "Test Config", "secure_launch_url" => "https://www.example.com/lti", "custom_params" => {"custom1" => "customval1"})
+    tc.extend IMS::LTI1_1::Extensions::Canvas::ToolConfig
   end
 
   it "should support default canvas extension parameters" do

--- a/spec/extensions/content_spec.rb
+++ b/spec/extensions/content_spec.rb
@@ -1,14 +1,14 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper.rb')
 
-describe IMS::LTI::Extensions do
+describe IMS::LTI1_1::Extensions do
   before do
     create_params
     @params['ext_content_intended_use'] = "homework"
     @params['ext_content_return_types'] = "file,url,lti_launch_url,image_url,iframe,oembed"
     @params['ext_content_return_url'] = "http://example.com/content_return?extra_param=foo"
     @params['ext_content_file_extensions'] = 'txt,jpg'
-    @tp = IMS::LTI::ToolProvider.new("hi", 'oi', @params)
-    @tp.extend IMS::LTI::Extensions::Content::ToolProvider
+    @tp = IMS::LTI1_1::ToolProvider.new("hi", 'oi', @params)
+    @tp.extend IMS::LTI1_1::Extensions::Content::ToolProvider
   end
 
   it "should correctly interpret extension parameters" do
@@ -124,8 +124,8 @@ describe IMS::LTI::Extensions do
 
   describe "tool consumer" do
     let(:tc) do
-      tc = IMS::LTI::ToolConsumer.new("hey", "ho")
-      tc.extend IMS::LTI::Extensions::Content::ToolConsumer
+      tc = IMS::LTI1_1::ToolConsumer.new("hey", "ho")
+      tc.extend IMS::LTI1_1::Extensions::Content::ToolConsumer
     end
 
     it "should accept content return types" do

--- a/spec/extensions/outcome_data_spec.rb
+++ b/spec/extensions/outcome_data_spec.rb
@@ -1,11 +1,11 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper.rb')
 
-describe IMS::LTI::Extensions do
+describe IMS::LTI1_1::Extensions do
   before do
     create_params
     @params['ext_outcome_data_values_accepted'] = 'text'
-    @tp = IMS::LTI::ToolProvider.new("hi", 'oi', @params)
-    @tp.extend IMS::LTI::Extensions::OutcomeData::ToolProvider
+    @tp = IMS::LTI1_1::ToolProvider.new("hi", 'oi', @params)
+    @tp.extend IMS::LTI1_1::Extensions::OutcomeData::ToolProvider
   end
 
   it "should correctly check supported data fields" do
@@ -17,8 +17,8 @@ describe IMS::LTI::Extensions do
   end
 
   it "should add TC functionality" do
-    tc = IMS::LTI::ToolConsumer.new("hey", "ho")
-    tc.extend IMS::LTI::Extensions::OutcomeData::ToolConsumer
+    tc = IMS::LTI1_1::ToolConsumer.new("hey", "ho")
+    tc.extend IMS::LTI1_1::Extensions::OutcomeData::ToolConsumer
     tc.support_outcome_data!
     tc.outcome_data_values_accepted.should == 'text,url,lti_launch_url,submitted_at'
     tc.outcome_data_values_accepted = 'url,text'
@@ -57,22 +57,22 @@ describe IMS::LTI::Extensions do
   end
 
   it "should parse replaceResult xml with extension val for url" do
-    req = IMS::LTI::OutcomeRequest.new
-    req.extend IMS::LTI::Extensions::OutcomeData::OutcomeRequest
+    req = IMS::LTI1_1::OutcomeRequest.new
+    req.extend IMS::LTI1_1::Extensions::OutcomeData::OutcomeRequest
     req.process_xml(result_xml % %{<resultData><url>http://www.example.com</url></resultData>})
     req.outcome_url.should == "http://www.example.com"
   end
 
   it "should parse replaceResult xml with extension val for ltiLaunchUrl" do
-    req = IMS::LTI::OutcomeRequest.new
-    req.extend IMS::LTI::Extensions::OutcomeData::OutcomeRequest
+    req = IMS::LTI1_1::OutcomeRequest.new
+    req.extend IMS::LTI1_1::Extensions::OutcomeData::OutcomeRequest
     req.process_xml(result_xml % %{<resultData><ltiLaunchUrl>http://www.example.com/launch</ltiLaunchUrl></resultData>})
     req.outcome_lti_launch_url.should == "http://www.example.com/launch"
   end
 
   it "should parse replaceResult xml with extension val for text" do
-    req = IMS::LTI::OutcomeRequest.new
-    req.extend IMS::LTI::Extensions::OutcomeData::OutcomeRequest
+    req = IMS::LTI1_1::OutcomeRequest.new
+    req.extend IMS::LTI1_1::Extensions::OutcomeData::OutcomeRequest
     req.process_xml(result_xml % %{<resultData><text>what the text</text></resultData>})
     req.outcome_text.should == "what the text"
   end

--- a/spec/launch_params_spec.rb
+++ b/spec/launch_params_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
-describe IMS::LTI::LaunchParams do
-  [IMS::LTI::ToolConsumer, IMS::LTI::ToolProvider].each do |tool|
+describe IMS::LTI1_1::LaunchParams do
+  [IMS::LTI1_1::ToolConsumer, IMS::LTI1_1::ToolProvider].each do |tool|
     context tool do
       before do
         create_params

--- a/spec/outcome_request_spec.rb
+++ b/spec/outcome_request_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-describe IMS::LTI::OutcomeRequest do
+describe IMS::LTI1_1::OutcomeRequest do
   before do
     create_test_tp
   end
@@ -21,7 +21,7 @@ describe IMS::LTI::OutcomeRequest do
   end
 
   it "should parse replaceResult xml" do
-    req = IMS::LTI::OutcomeRequest.new
+    req = IMS::LTI1_1::OutcomeRequest.new
     req.process_xml(replace_result_xml)
     req.operation.should == 'replaceResult'
     req.lis_result_sourcedid.should == '261-154-728-17-784'
@@ -30,7 +30,7 @@ describe IMS::LTI::OutcomeRequest do
   end
 
   it "should parse readResult xml" do
-    req = IMS::LTI::OutcomeRequest.new
+    req = IMS::LTI1_1::OutcomeRequest.new
     req.process_xml(read_result_xml)
     req.operation.should == 'readResult'
     req.lis_result_sourcedid.should == '261-154-728-17-784'
@@ -39,7 +39,7 @@ describe IMS::LTI::OutcomeRequest do
   end
 
   it "should parse deleteResult xml" do
-    req = IMS::LTI::OutcomeRequest.new
+    req = IMS::LTI1_1::OutcomeRequest.new
     req.process_xml(delete_result_xml)
     req.operation.should == 'deleteResult'
     req.lis_result_sourcedid.should == '261-154-728-17-784'
@@ -48,10 +48,10 @@ describe IMS::LTI::OutcomeRequest do
   end
 
   it "should generate request xml" do
-    req = IMS::LTI::OutcomeRequest.new(
+    req = IMS::LTI1_1::OutcomeRequest.new(
                                       :lis_result_sourcedid => '1234',
                                       :score => 0.5,
-                                      :operation => IMS::LTI::OutcomeRequest::REPLACE_REQUEST
+                                      :operation => IMS::LTI1_1::OutcomeRequest::REPLACE_REQUEST
     )
     xml = req.generate_request_xml
     xml.should be_a String

--- a/spec/outcome_response_spec.rb
+++ b/spec/outcome_response_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-describe IMS::LTI::OutcomeResponse do
+describe IMS::LTI1_1::OutcomeResponse do
 
   response_xml = <<-XML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -34,7 +34,7 @@ describe IMS::LTI::OutcomeResponse do
 
   it "should parse replaceResult response xml" do
     mock_response(response_xml)
-    res = IMS::LTI::OutcomeResponse.from_post_response(@fake)
+    res = IMS::LTI1_1::OutcomeResponse.from_post_response(@fake)
     res.success?.should == true
     res.code_major.should == 'success'
     res.severity.should == 'status'
@@ -57,7 +57,7 @@ describe IMS::LTI::OutcomeResponse do
     XML
     read_xml.gsub!('replaceResult', 'readResult')
     mock_response(read_xml)
-    res = IMS::LTI::OutcomeResponse.from_post_response(@fake)
+    res = IMS::LTI1_1::OutcomeResponse.from_post_response(@fake)
     res.success?.should == true
     res.code_major.should == 'success'
     res.severity.should == 'status'
@@ -69,7 +69,7 @@ describe IMS::LTI::OutcomeResponse do
 
   it "should parse readResult response xml" do
     mock_response(response_xml.gsub('replaceResult', 'deleteResult'))
-    res = IMS::LTI::OutcomeResponse.from_post_response(@fake)
+    res = IMS::LTI1_1::OutcomeResponse.from_post_response(@fake)
     res.success?.should == true
     res.code_major.should == 'success'
     res.severity.should == 'status'
@@ -81,20 +81,20 @@ describe IMS::LTI::OutcomeResponse do
 
   it "should recognize a failure response" do
     mock_response(response_xml.gsub('success', 'failure'))
-    res = IMS::LTI::OutcomeResponse.from_post_response(@fake)
+    res = IMS::LTI1_1::OutcomeResponse.from_post_response(@fake)
     res.failure?.should == true
   end
 
   it "should generate response xml" do
-    res = IMS::LTI::OutcomeResponse.new
+    res = IMS::LTI1_1::OutcomeResponse.new
     res.process_xml(response_xml)
     alt = response_xml.gsub("\n",'')
     res.generate_response_xml.should == alt
   end
 
   it "should raise an error with bad xml" do
-    res = IMS::LTI::OutcomeResponse.new
-    expect { res.process_xml(bad_xml) }.to raise_error(IMS::LTI::XMLParseError)
+    res = IMS::LTI1_1::OutcomeResponse.new
+    expect { res.process_xml(bad_xml) }.to raise_error(IMS::LTI1_1::XMLParseError)
   end
 
 end

--- a/spec/request_validator_spec.rb
+++ b/spec/request_validator_spec.rb
@@ -1,10 +1,10 @@
 require "spec_helper"
-describe IMS::LTI::RequestValidator do
+describe IMS::LTI1_1::RequestValidator do
   context "invalid request" do
     let(:oauth_signature_validator) { double("oauth_signature_validator") }
     before do
       create_params
-      @tool = IMS::LTI::ToolProvider.new("hooi", 'oi', @params)
+      @tool = IMS::LTI1_1::ToolProvider.new("hooi", 'oi', @params)
     end
 
     it "should raise OAuth::Unauthorized" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ end
 
 def create_test_tp
   create_params
-  @tp = IMS::LTI::ToolProvider.new("hi", 'oi', @params)
+  @tp = IMS::LTI1_1::ToolProvider.new("hi", 'oi', @params)
 end
 
 def expected_xml; %{<?xml version="1.0" encoding="UTF-8"?><imsx_POXEnvelopeRequest xmlns="http://www.imsglobal.org/services/ltiv1p1/xsd/imsoms_v1p0"><imsx_POXHeader><imsx_POXRequestHeaderInfo><imsx_version>V1.0</imsx_version><imsx_messageIdentifier>123456789</imsx_messageIdentifier></imsx_POXRequestHeaderInfo></imsx_POXHeader><imsx_POXBody>%s</imsx_POXBody></imsx_POXEnvelopeRequest>} end
@@ -40,7 +40,7 @@ def read_result_xml; expected_xml % %{<readResultRequest><resultRecord><sourcedG
 def delete_result_xml; expected_xml % %{<deleteResultRequest><resultRecord><sourcedGUID><sourcedId>261-154-728-17-784</sourcedId></sourcedGUID></resultRecord></deleteResultRequest>} end
 
 def mock_request(expected_xml)
-  IMS::LTI.stub(:generate_identifier).and_return("123456789")
+  IMS::LTI1_1.stub(:generate_identifier).and_return("123456789")
   @fake = Object
   OAuth::AccessToken.stub(:new).and_return(@fake)
   @fake.should_receive(:code).and_return("200")

--- a/spec/tool_config_spec.rb
+++ b/spec/tool_config_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-describe IMS::LTI::ToolConfig do
+describe IMS::LTI1_1::ToolConfig do
 
   cc_lti_xml = <<XML
 <?xml version="1.0" encoding="UTF-8"?>
@@ -48,7 +48,7 @@ XML
   end
 
   it "should generate the expected config xml" do
-    config = IMS::LTI::ToolConfig.new("title" => "Test Config", "secure_launch_url" => "https://www.example.com/lti", "custom_params" => {"custom1" => "customval1"})
+    config = IMS::LTI1_1::ToolConfig.new("title" => "Test Config", "secure_launch_url" => "https://www.example.com/lti", "custom_params" => {"custom1" => "customval1"})
     config.description = "Description of boringness"
     config.launch_url = "http://www.example.com/lti"
     config.icon = "http://wil.to/_/beardslap.gif"
@@ -80,13 +80,13 @@ XML
   end
 
   it "should read an xml config" do
-    config = IMS::LTI::ToolConfig.create_from_xml(cc_lti_xml)
+    config = IMS::LTI1_1::ToolConfig.create_from_xml(cc_lti_xml)
     clear_shema_stuffs(config.to_xml(:indent => 2)).should == clear_shema_stuffs(cc_lti_xml)
   end
 
   it "should not allow creating invalid config xml" do
-    config = IMS::LTI::ToolConfig.new("title" => "Test Config")
-    expect { config.to_xml }.to raise_error(IMS::LTI::InvalidLTIConfigError)
+    config = IMS::LTI1_1::ToolConfig.new("title" => "Test Config")
+    expect { config.to_xml }.to raise_error(IMS::LTI1_1::InvalidLTIConfigError)
   end
 
 end

--- a/spec/tool_consumer_spec.rb
+++ b/spec/tool_consumer_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
-describe IMS::LTI::ToolConsumer do
+describe IMS::LTI1_1::ToolConsumer do
   def create_tc
     # This is the example in the docs at: http://www.imsglobal.org/LTI/v1p1pd/ltiIMGv1p1pd.html#_Toc309649707
-    @tc = IMS::LTI::ToolConsumer.new('12345', 'secret')
+    @tc = IMS::LTI1_1::ToolConsumer.new('12345', 'secret')
     @tc.launch_url = 'http://dr-chuck.com/ims/php-simple/tool.php'
     @tc.timestamp = '1251600739'
     @tc.nonce = 'c8350c0e47782d16d2fa48b2090c1d8f'
@@ -38,7 +38,7 @@ describe IMS::LTI::ToolConsumer do
   end
 
   it "should generate a correct signature with a non-standard port" do
-    @tc = IMS::LTI::ToolConsumer.new('12345', 'secret', 'resource_link_id' => 1)
+    @tc = IMS::LTI1_1::ToolConsumer.new('12345', 'secret', 'resource_link_id' => 1)
     @tc.timestamp = '1251600739'
     @tc.nonce = 'c8350c0e47782d16d2fa48b2090c1d8f'
 
@@ -60,7 +60,7 @@ describe IMS::LTI::ToolConsumer do
   end
 
   it "should include URI query parameters" do
-    @tc = IMS::LTI::ToolConsumer.new('12345', 'secret', 'resource_link_id' => 1, 'user_id' => 2)
+    @tc = IMS::LTI1_1::ToolConsumer.new('12345', 'secret', 'resource_link_id' => 1, 'user_id' => 2)
     @tc.launch_url = 'http://www.yahoo.com?a=1&b=2'
     hash = @tc.generate_launch_data
     hash['a'].should == '1'
@@ -68,7 +68,7 @@ describe IMS::LTI::ToolConsumer do
   end
 
   it "should not allow overwriting other parameters from the URI query string" do
-    @tc = IMS::LTI::ToolConsumer.new('12345', 'secret', 'resource_link_id' => 1, 'user_id' => 2)
+    @tc = IMS::LTI1_1::ToolConsumer.new('12345', 'secret', 'resource_link_id' => 1, 'user_id' => 2)
     @tc.launch_url = 'http://www.yahoo.com?user_id=123&lti_message_type=1234'
     hash = @tc.generate_launch_data
     hash['user_id'].should == '2'

--- a/spec/tool_provider_spec.rb
+++ b/spec/tool_provider_spec.rb
@@ -1,5 +1,5 @@
 require "spec_helper"
-describe IMS::LTI::ToolProvider do
+describe IMS::LTI1_1::ToolProvider do
   #todo test stuff from certification: http://www.imsglobal.org/developers/alliance/LTI/cert-v1p1/
   before do
     create_test_tp


### PR DESCRIPTION
This is to be able to use the gem version 2.x along with 1.2.x and that's needed because the 2.x implements LTI 1.3 and 1.2.x imnplements LTI 1.1.